### PR TITLE
Drop broken coding comment

### DIFF
--- a/asyncio_pool/__init__.py
+++ b/asyncio_pool/__init__.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import sys
 
 from .results import getres

--- a/asyncio_pool/base_pool.py
+++ b/asyncio_pool/base_pool.py
@@ -1,4 +1,3 @@
-# coding: utf8
 '''Pool of asyncio coroutines with familiar interface, python3.5+ friendly'''
 
 import traceback

--- a/asyncio_pool/mx_asyncgen.py
+++ b/asyncio_pool/mx_asyncgen.py
@@ -1,4 +1,3 @@
-# coding: utf8
 '''Mixin for BaseAioPool with async generator features, python3.6+'''
 
 import asyncio as aio

--- a/asyncio_pool/mx_asynciter.py
+++ b/asyncio_pool/mx_asynciter.py
@@ -1,4 +1,3 @@
-# coding: utf8
 '''Mixin for BaseAioPool with async generator _simulation_ for python 3.5'''
 
 import asyncio as aio

--- a/asyncio_pool/results.py
+++ b/asyncio_pool/results.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 from functools import partial
 
 

--- a/examples/_usage.py
+++ b/examples/_usage.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import os
 import sys
 curr_dir = os.path.dirname(os.path.abspath(__file__))

--- a/examples/ls_remote.py
+++ b/examples/ls_remote.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import os
 import sys
 curr_dir = os.path.dirname(os.path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import setuptools
 
 

--- a/tests/loadtest.py
+++ b/tests/loadtest.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import os
 import sys
 curr_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import pytest
 import asyncio as aio
 from asyncio_pool import AioPool

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import pytest
 import asyncio as aio
 from asyncio_pool import AioPool, getres

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import pytest
 import asyncio as aio
 from asyncio_pool import AioPool, getres

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import pytest
 import asyncio as aio
 from asyncio_pool import AioPool


### PR DESCRIPTION
When trying to print a backtrace for CancelledError, I got the following error:

```
Traceback (most recent call last):
  File "/nix/store/bs03sg8b0gq2zr4v252hh9psp780qj5q-python3-3.8.5/lib/python3.8/tokenize.py", line 342, in find_cookie
    codec = lookup(encoding)
LookupError: unknown encoding: utf8
```

Let's remove the coding comment altogether as only Python 3 is supported and that defaults to UTF-8:

https://docs.python.org/3/reference/lexical_analysis.html#encoding-declarations
