### PR TITLE
asyncio.wait() no longer supports the "loop" argument as of Python 3.10

### DIFF
--- a/asyncio_pool/mx_asyncgen.py
+++ b/asyncio_pool/mx_asyncgen.py
@@ -5,7 +5,7 @@ from .results import getres
 
 
 async def iterwait(futures, *, flat=True, get_result=getres.flat,
-        timeout=None, yield_when=aio.ALL_COMPLETED, loop=None):
+        timeout=None, yield_when=aio.ALL_COMPLETED):
     '''Wraps `asyncio.wait` into asynchronous generator, accessible with
     `async for` syntax. May be useful in conjunction with `spawn_n`.
 
@@ -19,7 +19,7 @@ async def iterwait(futures, *, flat=True, get_result=getres.flat,
     _futures = futures[:]
     while _futures:
         done, _futures = await aio.wait(_futures, timeout=timeout,
-                                        return_when=yield_when, loop=loop)
+                                        return_when=yield_when)
         if flat:
             for fut in done:
                 yield get_result(fut)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,13 +6,14 @@ py36=python3.6
 py37=python3.7
 py38=python3.8
 py39=python3.9
+py310=python3.10
 
 default_env=$py37
 
 
 todo=${@:-"./tests"}
 
-for py in $py35 $py36 $py37 $py38 $py39 $pypy3
+for py in $pypy3 $py35 $py36 $py37 $py38 $py39 $py310
 do
     echo ""
     if [ -x "$(command -v $py)" ]; then

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -6,11 +6,12 @@ py36=python3.6
 py37=python3.7
 py38=python3.8
 py39=python3.9
+py310=python3.10
 
 default_env=$py37
 
 
-for py in $pypy3 $py35 $py36 $py37 $py38 $py39
+for py in $pypy3 $py35 $py36 $py37 $py38 $py39 $py310
 do
     if [ -x "$(command -v $py)" ]; then
         pyname="$(basename $py)"


### PR DESCRIPTION
I was playing around with Python 3.10 and found/fixed this incompatibility. Tests are all passing for python3.5-3.10. I was not able to get pypy3 installed so it was no tested.

Thanks!
Kyle