### PR TITLE
Do not fail on mapping empty collections

### DIFF
--- a/asyncio_pool/base_pool.py
+++ b/asyncio_pool/base_pool.py
@@ -238,6 +238,9 @@ class BaseAioPool(object):
             fut = await self.spawn(fn(it), cb, ctx)
             futures.append(fut)
 
+        if not futures:
+            return []
+
         await aio.wait(futures)
         return [get_result(fut) for fut in futures]
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -17,6 +17,14 @@ async def test_map_simple():
 
 
 @pytest.mark.asyncio
+async def test_map_empty():
+    task = []
+    pool = AioPool(size=7)
+    res = await pool.map(wrk, task)
+    assert res == []
+
+
+@pytest.mark.asyncio
 async def test_map_crash():
     task = range(5)
     pool = AioPool(size=10)
@@ -50,6 +58,17 @@ async def test_itermap():
             else:
                 assert False  # should not get here
             i += 1  # does not support enumerate btw (
+
+
+@pytest.mark.asyncio
+async def test_itermap_empty():
+    async def wrk(n):
+        await aio.sleep(n)
+        return n
+
+    async with AioPool(size=3) as pool:
+        async for res in pool.itermap(wrk, [], flat=False, timeout=0.6):
+            assert False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is quite natural for map function to be a no-op and return an empty collection when input is also empty (the examples are the python's own `map` function and nodejs' `array.map`) rather than throwing an error which it does at the moment.

Itermap does seem to be working this way already bu i've added a test for an empty input as well, just in case. 